### PR TITLE
Use the download route filename bit to add it.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -59,7 +59,11 @@ function template_preprocess_islandora_pdf(array &$variables) {
 
       // Sanitize this object name a bit and provide download link.
       $sanitized_label = preg_replace('/[^A-Za-z0-9_\-]|\.pdf$/', '_', $islandora_object->label);
-      $download_url = Url::fromUserInput("/islandora/object/{$islandora_object->id}/datastream/OBJ/download/{$sanitized_label}.pdf");
+      $download_url = Url::fromRoute('islandora.download_datastream', [
+        'object' => $islandora_object->id,
+        'datastream' => 'OBJ',
+        'filename' => "{$sanitized_label}.pdf",
+      ]);
       $download_url->setOptions(['attributes' => ['class' => ['islandora-pdf-link']]]);
       $islandora_download_link = Link::fromTextAndUrl(
         t("Download pdf"),

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -63,8 +63,7 @@ function template_preprocess_islandora_pdf(array &$variables) {
         'object' => $islandora_object->id,
         'datastream' => 'OBJ',
         'filename' => "{$sanitized_label}.pdf",
-      ]);
-      $download_url->setOptions(['attributes' => ['class' => ['islandora-pdf-link']]]);
+      ], ['attributes' => ['class' => ['islandora-pdf-link']]]);
       $islandora_download_link = Link::fromTextAndUrl(
         t("Download pdf"),
         $download_url


### PR DESCRIPTION
Dependent on https://github.com/discoverygarden/islandora/pull/12

# What does this Pull Request do?

Use the routing mechanism to build the download URL.

# How should this be tested?

Smoketest: The "Download PDF" link renders and functions.

The "NOTE" from https://github.com/discoverygarden/islandora/pull/12 should be kept in mind here, with the disconnect between the object label in the URL vs the datastream label being used.

# Additional Notes:

* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Unlikely.